### PR TITLE
change twitter link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ github_url: https://github.com/readchina
 # linkedin_url: https://www.linkedin.com/in/andrew-banchich-a4ba1195
 # pinterest_url:
 # slack_url:
-twitter_url: https://twitter.com/readchina
+twitter_url: https://twitter.com/zhong_daming
 
 # build settings
 markdown: kramdown


### PR DESCRIPTION
I added for now the link to my twitter as removing the icon etc would be too much work before we go live today -- we can change that for a RC account once we have one