### PR TITLE
interventions page + post

### DIFF
--- a/_posts/2021-04-01-Interventions1.md
+++ b/_posts/2021-04-01-Interventions1.md
@@ -1,0 +1,57 @@
+---
+layout: post
+title: READCHINA Interventions, No.1: What is a Reading Act?
+---
+<!-- Content -->
+<h2 id="content">READCHINA Interventions, No.1: What is a Reading Act?</h2>
+<p>Praesent ac adipiscing ullamcorper semper ut amet ac risus. Lorem sapien ut odio odio nunc. Ac adipiscing nibh porttitor erat risus justo adipiscing adipiscing amet placerat accumsan. Vis. Faucibus odio magna tempus adipiscing a non. In mi primis arcu ut non accumsan vivamus ac blandit adipiscing adipiscing arcu metus praesent turpis eu ac lacinia nunc ac commodo gravida adipiscing eget accumsan ac nunc adipiscing adipiscing.</p>
+
+<h3>Text</h3>
+<p>This is <b>bold</b> and this is <strong>strong</strong>. This is <i>italic</i> and this is <em>emphasized</em>.
+This is <sup>superscript</sup> text and this is <sub>subscript</sub> text.
+This is <u>underlined</u> and this is code: <code>for (;;) { ... }</code>.
+Finally, this is a <a href="#">link</a>.</p>
+<hr />
+<h2>Heading Level 2</h2>
+<h3>Heading Level 3</h3>
+<h4>Heading Level 4</h4>
+<hr />
+<p>Nunc lacinia ante nunc ac lobortis. Interdum adipiscing gravida odio porttitor sem non mi integer non faucibus ornare mi ut ante amet placerat aliquet. Volutpat eu sed ante lacinia sapien lorem accumsan varius montes viverra nibh in adipiscing blandit tempus accumsan.</p>
+
+<!-- Blockquote -->
+<h3>Blockquote</h3>
+<blockquote>Fringilla nisl. Donec accumsan interdum nisi, quis tincidunt felis sagittis eget tempus euismod. Vestibulum ante ipsum primis in faucibus vestibulum. Blandit adipiscing eu felis iaculis volutpat ac adipiscing accumsan faucibus. Vestibulum ante ipsum primis in faucibus vestibulum. Blandit adipiscing eu felis.</blockquote>
+
+<!-- Form -->
+<h4>Thougts? Comments? Ideas? Share them with us!</h4>
+
+<form method="post" action="#">
+	<div class="row uniform">
+		<div class="6u 12u$(xsmall)">
+			<input type="text" name="demo-name" id="demo-name" value="" placeholder="Name" />
+		</div>
+		<div class="6u$ 12u$(xsmall)">
+			<input type="email" name="demo-email" id="demo-email" value="" placeholder="Email" />
+		</div>
+		<!-- Break -->
+		<div class="6u 12u$(small)">
+			<input type="checkbox" id="demo-copy" name="demo-copy">
+			<label for="demo-copy">Email me a copy</label>
+		</div>
+		<div class="6u$ 12u$(small)">
+			<input type="checkbox" id="demo-human" name="demo-human" checked>
+			<label for="demo-human">I am a human</label>
+		</div>
+		<!-- Break -->
+		<div class="12u$">
+			<textarea name="demo-message" id="demo-message" placeholder="Enter your message" rows="6"></textarea>
+		</div>
+		<!-- Break -->
+		<div class="12u$">
+			<ul class="actions">
+				<li><input type="submit" value="Send Message" class="special" /></li>
+				<li><input type="reset" value="Reset" /></li>
+			</ul>
+		</div>
+	</div>
+</form>

--- a/interventions.md
+++ b/interventions.md
@@ -1,0 +1,19 @@
+---
+layout: page
+title: READCHINA Interventions
+nav-menu: true
+show_tile: true
+---
+
+<!-- Main -->
+<div id="main" class="alt">
+
+<!-- One -->
+<section id="one">
+	<div class="inner">
+		<header class="major">
+			<h1>READCHINA Interventions</h1>
+		</header>
+
+<!-- Content -->
+<p>Here comes a nice description of what the RC Interventions series is all about.</p>


### PR DESCRIPTION
Hi! So, I created a page for the RC Interventions which also shows on the tiles and navmenu, I think that is all fine and pretty:

<img width="1433" alt="image" src="https://user-images.githubusercontent.com/35594124/112616082-98978b00-8e23-11eb-9b80-d037a24ec2d5.png">

<img width="1432" alt="image" src="https://user-images.githubusercontent.com/35594124/112616093-9af9e500-8e23-11eb-8c61-802f8ddc61f9.png">

I also created a sample post for the interventions with various text options, blockquote & a form for soliciting comments -- I thought we will add them like this (each intervention = one post) but it seems that posts only and automatically appear in the activity page... Hope @duncdrum has some neat solution to that ;)